### PR TITLE
Fix Setup BATS Version Numbers

### DIFF
--- a/.github/workflows/clean_tests.yml
+++ b/.github/workflows/clean_tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Setup BATS testing framework
-      uses: mig4/setup-bats@v1.0.1
+      uses: mig4/setup-bats@v1.2.0
     - name: Check out the code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/compile_tests.yml
+++ b/.github/workflows/compile_tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Setup BATS testing framework
-      uses: mig4/setup-bats@v1.0.1
+      uses: mig4/setup-bats@v1.2.0
     - name: Check out the code
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
This merging of `fix-setup-bats-numbers` into `main` is meant to fix the version numbers of the Setup BATS testing framework. It is needed in order to ensure that the test badges activate correctly when the tests are complete.